### PR TITLE
[#346] 뷰 트랜지션 점검

### DIFF
--- a/Mohaeng/Mohaeng/Resources/Colors.xcassets/Mohaeng-Fix/YellowIconNavi.colorset/Contents.json
+++ b/Mohaeng/Mohaeng/Resources/Colors.xcassets/Mohaeng-Fix/YellowIconNavi.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.325",
+          "green" : "0.769",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.325",
+          "green" : "0.769",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mohaeng/Mohaeng/Resources/Storyboards/Challenge/Course.storyboard
+++ b/Mohaeng/Mohaeng/Resources/Storyboards/Challenge/Course.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TuI-sr-lBb">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -12,13 +13,13 @@
         <!--Course View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="CourseViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="CourseViewController" customModule="Journey" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CourseViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="CourseViewController" customModule="Mohaeng" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="8at-xF-psI">
-                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <color key="backgroundColor" name="BgLightYellow"/>
                             </tableView>
                         </subviews>
@@ -31,16 +32,38 @@
                             <constraint firstItem="8at-xF-psI" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="r0L-Ye-4h8"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="CMV-2S-H2B"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="courseTableView" destination="8at-xF-psI" id="VAy-u0-i5v"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="939.13043478260875" y="67.633928571428569"/>
+        </scene>
+        <!--챌린지-->
+        <scene sceneID="IVp-gs-VCh">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="TuI-sr-lBb" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="챌린지" image="challengeIcon" id="cUU-n5-gkM"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="gGg-fW-Rh7">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="MaQ-X8-mFR"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="m9q-p3-rOL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
             <point key="canvasLocation" x="28.985507246376812" y="67.633928571428569"/>
         </scene>
     </scenes>
     <resources>
+        <image name="challengeIcon" width="28" height="28"/>
         <namedColor name="BgLightYellow">
             <color red="1" green="0.98400002717971802" blue="0.93699997663497925" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Mohaeng/Mohaeng/Resources/Storyboards/Tabbar.storyboard
+++ b/Mohaeng/Mohaeng/Resources/Storyboards/Tabbar.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HqF-25-05f">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HqF-25-05f">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -10,7 +11,7 @@
         <!--Tabbar View Controller-->
         <scene sceneID="3Yy-GQ-m75">
             <objects>
-                <tabBarController storyboardIdentifier="TabbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="HqF-25-05f" customClass="TabbarViewController" customModule="Journey" customModuleProvider="target" sceneMemberID="viewController">
+                <tabBarController storyboardIdentifier="TabbarViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="HqF-25-05f" customClass="TabbarViewController" customModule="Mohaeng" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="4dC-sB-NL4">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -38,10 +39,10 @@
             </objects>
             <point key="canvasLocation" x="-901" y="82"/>
         </scene>
-        <!--Challenge-->
+        <!--Course-->
         <scene sceneID="Tyy-rw-BPx">
             <objects>
-                <viewControllerPlaceholder storyboardName="Challenge" id="h8u-sX-FfF" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardName="Course" id="h8u-sX-FfF" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="prF-vF-3Am"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Y7f-VJ-eod" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Mohaeng/Mohaeng/Resources/Storyboards/Tabbar.storyboard
+++ b/Mohaeng/Mohaeng/Resources/Storyboards/Tabbar.storyboard
@@ -16,8 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="tintColor" name="Pink2"/>
-                        <color key="selectedImageTintColor" name="Pink2"/>
+                        <color key="tintColor" name="YellowIconNavi"/>
+                        <color key="selectedImageTintColor" name="YellowIconNavi"/>
                     </tabBar>
                     <connections>
                         <segue destination="gfI-Hd-mIH" kind="relationship" relationship="viewControllers" id="dSz-nP-RyZ"/>
@@ -61,8 +61,8 @@
         </scene>
     </scenes>
     <resources>
-        <namedColor name="Pink2">
-            <color red="1" green="0.52899998426437378" blue="0.6470000147819519" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="YellowIconNavi">
+            <color red="1" green="0.76862745098039209" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/Mohaeng/Mohaeng/Sources/Cells/CourseTableView/EvenDayTableViewCell.swift
+++ b/Mohaeng/Mohaeng/Sources/Cells/CourseTableView/EvenDayTableViewCell.swift
@@ -97,7 +97,7 @@ class EvenDayTableViewCell: UITableViewCell {
     func setNextSituation(next: Int) {
         switch next {
         case 0:
-            nextLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+            nextLine.strokeColor = UIColor.Grey4.cgColor
             setDashedLine(line: nextLine)
         case 1:
             nextLine.strokeColor = UIColor.sampleGreen.cgColor
@@ -115,7 +115,7 @@ class EvenDayTableViewCell: UITableViewCell {
     private func setColorBySituation(situation: Int) {
         switch situation {
         case 0: // 진행 전 챌린지
-            currentLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+            currentLine.strokeColor = UIColor.Grey4.cgColor
             setDashedLine(line: currentLine)
         
         case 1: // 진행 중인 챌린지

--- a/Mohaeng/Mohaeng/Sources/Cells/CourseTableView/FirstDayTableViewCell.swift
+++ b/Mohaeng/Mohaeng/Sources/Cells/CourseTableView/FirstDayTableViewCell.swift
@@ -129,7 +129,7 @@ class FirstDayTableViewCell: UITableViewCell {
     func setNextSituation(next: Int) {
         switch next {
         case 0:
-            nextLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+            nextLine.strokeColor = UIColor.Grey4.cgColor
             setDashedLine(line: nextLine)
         case 1:
             nextLine.strokeColor = UIColor.sampleGreen.cgColor
@@ -147,7 +147,7 @@ class FirstDayTableViewCell: UITableViewCell {
     private func setColorBySituation(situation: Int) {
         switch situation {
         case 0: // 진행 전 챌린지
-            currentLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+            currentLine.strokeColor = UIColor.Grey4.cgColor
             setDashedLine(line: currentLine)
         
         case 1: // 진행 중인 챌린지

--- a/Mohaeng/Mohaeng/Sources/Cells/CourseTableView/OddDayTableViewCell.swift
+++ b/Mohaeng/Mohaeng/Sources/Cells/CourseTableView/OddDayTableViewCell.swift
@@ -67,7 +67,7 @@ class OddDayTableViewCell: UITableViewCell {
         nextLine.lineCap = .round
         nextLine.lineDashPhase = 5
         nextLine.lineDashPattern = [RoadMapPath(centerY: 0).getDashPattern(), RoadMapPath(centerY: 0).getBlankPattern()]
-        nextLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+        nextLine.strokeColor = UIColor.Grey4.cgColor
         
         self.contentView.layer.insertSublayer(nextLine, at: 2)
     }
@@ -99,7 +99,7 @@ class OddDayTableViewCell: UITableViewCell {
     func setNextSituation(next: Int) {
         switch next {
         case 0:
-            nextLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+            nextLine.strokeColor = UIColor.Grey4.cgColor
             setDashedLine(line: nextLine)
         case 1:
             nextLine.strokeColor = UIColor.sampleGreen.cgColor
@@ -123,7 +123,7 @@ class OddDayTableViewCell: UITableViewCell {
     private func setColorBySituation(situation: Int) {
         switch situation {
         case 0: // 진행 전 챌린지
-            currentLine.strokeColor = UIColor.roadUndoneGrey.cgColor
+            currentLine.strokeColor = UIColor.Grey4.cgColor
             setDashedLine(line: currentLine)
         
         case 1: // 진행 중인 챌린지

--- a/Mohaeng/Mohaeng/Sources/Extensions/UIColor+Extension.swift
+++ b/Mohaeng/Mohaeng/Sources/Extensions/UIColor+Extension.swift
@@ -55,7 +55,6 @@ extension UIColor {
     // MARK: - Mohaeng
     
     static let sampleGreen: UIColor = UIColor(named: "SampleGreen")!
-    static let roadUndoneGrey: UIColor = UIColor(named: "RoadUndoneGrey")!
     static let todayYellow: UIColor = UIColor(named: "todayYellow")!
     static let YellowText1: UIColor = UIColor(named: "YellowText1")!
     

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/LoginViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/LoginViewController.swift
@@ -18,16 +18,6 @@ class LoginViewController: UIViewController {
     @IBOutlet weak var emailStackView: UIStackView!
     @IBOutlet weak var passwordStackView: UIStackView!
     
-    private lazy var activityIndicator: UIActivityIndicatorView = {
-        let activityIndicator = UIActivityIndicatorView()
-        activityIndicator.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
-        activityIndicator.center = CGPoint(x: self.view.center.x, y: self.view.center.y - self.topbarHeight)
-        activityIndicator.hidesWhenStopped = false
-        activityIndicator.style = UIActivityIndicatorView.Style.medium
-        activityIndicator.startAnimating()
-        return activityIndicator
-    }()
-    
     var backgroundView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
     
     // MARK: - View Life Cycle
@@ -43,7 +33,8 @@ class LoginViewController: UIViewController {
     // MARK: - @IBAction Functions
     
     @IBAction func touchLoginButton(_ sender: Any) {
-        postLogin()
+        self.presentHomeViewController()
+        // postLogin()
     }
     
     @IBAction func findPasswordButton(_ sender: Any) {
@@ -73,15 +64,6 @@ class LoginViewController: UIViewController {
     private func attachActivityIndicator() {
         backgroundView.backgroundColor = UIColor.white
         self.view.addSubview(backgroundView)
-        self.view.addSubview(self.activityIndicator)
-    }
-    
-    private func detachActivityIndicator() {
-        if self.activityIndicator.isAnimating {
-            self.activityIndicator.stopAnimating()
-        }
-        self.backgroundView.removeFromSuperview()
-        self.activityIndicator.removeFromSuperview()
     }
     
     private func makeButtonRound() {
@@ -140,7 +122,6 @@ extension LoginViewController {
                 if let data = jwt as? JwtData {
                     UserDefaults.standard.setValue(data.jwt, forKey: "jwtToken")
                     print(data.jwt)
-                    self.detachActivityIndicator()
                     self.presentHomeViewController()
                 }
             case .requestErr(let message):

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Challenge/CourseViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Challenge/CourseViewController.swift
@@ -15,6 +15,7 @@ class CourseViewController: UIViewController {
     // default data
     var course: Course = Course(id: 0, title: "", courseDescription: "", totalDays: 0, situation: 0, property: 0, challenges: [
         Challenge(id: 0, situation: 0, title: "", challengeDescription: "", successDescription: "", year: "", month: "", day: "", currentStamp: 0, totalStamp: 0, userMents: []),
+        Challenge(id: 0, situation: 0, title: "", challengeDescription: "", successDescription: "", year: "", month: "", day: "", currentStamp: 0, totalStamp: 0, userMents: []),
         Challenge(id: 0, situation: 0, title: "", challengeDescription: "", successDescription: "", year: "", month: "", day: "", currentStamp: 0, totalStamp: 0, userMents: [])
     ])
 

--- a/Mohaeng/Mohaeng/Sources/Views/CourseFooterView.swift
+++ b/Mohaeng/Mohaeng/Sources/Views/CourseFooterView.swift
@@ -42,7 +42,7 @@ class CourseFooterView: UITableViewHeaderFooterView {
         case .undone:
             line.lineDashPhase = 5
             line.lineDashPattern = [RoadMapPath(centerY: 0).getDashPattern(), RoadMapPath(centerY: 0).getBlankPattern()]
-            line.strokeColor = UIColor.roadUndoneGrey.cgColor
+            line.strokeColor = UIColor.Grey4.cgColor
         case .none:
             return
         }


### PR DESCRIPTION
### Description
디팟한테 보여주기 전 전체적으로 뷰 트랜지션을 점검했습니다.
SceneDelegate에서 RootVC 변경할 필요 없이
![image](https://user-images.githubusercontent.com/28949235/135746024-0f626045-532c-4203-980e-c8638c95af0b.png)
로그인 버튼 클릭하면 메인으로 이동합니다. ( 로그인 통신 떼어놨음 )

### 챌린지
 탭바 챌린지탭 VC 변경
 Course뷰 탭바 아이템 추가
 Course뷰 roadUndoneGrey → Grey4로 색상 변경
### 로그인 뷰
 activity indicator 삭제
 통신 잠시 주석처리
### 탭바
 YellowIconNavi Color Asset 추가
 tint color 변경

### Related Issue
Resolve #346 