### PR TITLE
[#235] 로그인 실패 시 에러 팝업 띄우기

### DIFF
--- a/Mohaeng/Mohaeng/Resources/Constants/String.swift
+++ b/Mohaeng/Mohaeng/Resources/Constants/String.swift
@@ -22,6 +22,12 @@ extension Const {
         // 회원 탈퇴 팝업
         static let withdrawalPopUpTitle = "회원 탈퇴하기"
         static let withdrawalPopUpContent = "탈퇴하면 그동안 모아왔던 해피지수와 캐릭터 스타일 카드가 모두 사라져!"
+        
+        // MARK: - Error Strings
+        
+        static let pathErr = "pathErr 발생. 개발자에게 문의해주세요."
+        static let serverErr = "serverErr 발생. 개발자에게 문의해주세요."
+        static let networkFail = "네트워크 상태가 좋지 않습니다. 잠시 후 다시 시도해주세요."
     }
     
 }

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/LoginViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/LoginViewController.swift
@@ -17,6 +17,7 @@ class LoginViewController: UIViewController {
     // MARK: - Properties
     
     var signUpUser = SignUpUser.shared
+    var errorPopUp: PopUpViewController = PopUpViewController()
     
     // MARK: - @IBOutlet Properties
     
@@ -141,7 +142,18 @@ class LoginViewController: UIViewController {
         tabbarViewController.modalTransitionStyle = .crossDissolve
         self.present(tabbarViewController, animated: true, completion: nil)
     }
+    
+    func presentPopUp(errorString: String) {
+        errorPopUp = PopUpViewController(nibName: Const.Xib.Name.popUp, bundle: nil)
+        errorPopUp.modalPresentationStyle = .overCurrentContext
+        errorPopUp.modalTransitionStyle = .crossDissolve
+        errorPopUp.popUpUsage = .noButton
+        errorPopUp.setText(title: "로그인 실패", description: errorString)
+        self.present(errorPopUp, animated: true, completion: nil)
+    }
 }
+
+// MARK: - 통신
 
 extension LoginViewController {
     
@@ -163,12 +175,17 @@ extension LoginViewController {
                 }
                 
             case .requestErr(let message):
-                print("requestErr", message)
+                if let message = message as? String {
+                    self.presentPopUp(errorString: message)
+                }
             case .pathErr:
+                self.presentPopUp(errorString: Const.String.pathErr)
                 print("pathErr")
             case .serverErr:
+                self.presentPopUp(errorString: Const.String.serverErr)
                 print("serverErr")
             case .networkFail:
+                self.presentPopUp(errorString: Const.String.networkFail)
                 print("networkFail")
             }
         }
@@ -192,12 +209,18 @@ extension LoginViewController {
                 }
                 
             case .requestErr(let message):
+                if let message = message as? String {
+                    self.presentPopUp(errorString: message)
+                }
                 print("requestErr", message)
             case .pathErr:
+                self.presentPopUp(errorString: Const.String.pathErr)
                 print("pathErr")
             case .serverErr:
+                self.presentPopUp(errorString: Const.String.serverErr)
                 print("serverErr")
             case .networkFail:
+                self.presentPopUp(errorString: Const.String.networkFail)
                 print("networkFail")
             }
         }
@@ -243,6 +266,7 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
         }
     }
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        presentPopUp(errorString: error.localizedDescription)
         print(error)
     }
     

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/SignUpFirstViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/SignUpFirstViewController.swift
@@ -396,7 +396,6 @@ extension SignUpFirstViewController {
         SignUpAPI.shared.postEmailCheck(completion: { [self] (response) in
             switch response {
             case .success(let message):
-                print("success")
                 changeAttributesSuccess()
             case .requestErr(let message):
                 print("requestErr", message)

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/SignUpThirdViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Auth/SignUpThirdViewController.swift
@@ -19,6 +19,9 @@ class SignUpThirdViewController: UIViewController {
     }
     
     var nicknameUsage: NicknameUsage?
+    
+    var errorPopUp: PopUpViewController = PopUpViewController()
+    
     // MARK: - @IBOutlet Properties
     
     @IBOutlet var nickNameSetLabel: UILabel!
@@ -28,6 +31,7 @@ class SignUpThirdViewController: UIViewController {
     @IBOutlet weak var checkButton: UIButton!
     @IBOutlet var nickNameConditionLabel: UILabel!
     @IBOutlet var imageToNicknameTextField: NSLayoutConstraint!
+    
     // MARK: - View Life Cycle
     
     override func viewDidLoad() {
@@ -124,6 +128,15 @@ class SignUpThirdViewController: UIViewController {
         nickNameTextField.addTarget(self, action: #selector(SignUpThirdViewController.textFieldDidChange(_:)), for: UIControl.Event.allEditingEvents)
     }
     
+    func presentPopUp(errorString: String) {
+        errorPopUp = PopUpViewController(nibName: Const.Xib.Name.popUp, bundle: nil)
+        errorPopUp.modalPresentationStyle = .overCurrentContext
+        errorPopUp.modalTransitionStyle = .crossDissolve
+        errorPopUp.popUpUsage = .noButton
+        errorPopUp.setText(title: "에러", description: errorString)
+        self.present(errorPopUp, animated: true, completion: nil)
+    }
+    
     // MARK: @objc Function
     
     @objc func textFieldDidChange(_ textField: UITextField) {
@@ -141,6 +154,7 @@ class SignUpThirdViewController: UIViewController {
             setEmptyNickNameTextField()
         }
     }
+    
     @IBAction func touchNicknameCheckButton(_ sender: UIButton) {
         
         switch nicknameUsage {
@@ -168,6 +182,8 @@ class SignUpThirdViewController: UIViewController {
     
 }
 
+// MARK: - 통신
+
 extension SignUpThirdViewController {
     
     // 소셜 회원가입
@@ -187,11 +203,19 @@ extension SignUpThirdViewController {
                 
             case .requestErr(let message):
                 print("requestErr", message)
+                if let message = message as? String {
+                    self.nickNameErrorLabel.isHidden = false
+                    self.nickNameErrorLabel.text = message
+                    self.nickNameBottomView.backgroundColor = .Red
+                }
             case .pathErr:
+                self.presentPopUp(errorString: Const.String.pathErr)
                 print("pathErr")
             case .serverErr:
+                self.presentPopUp(errorString: Const.String.serverErr)
                 print("serverErr")
             case .networkFail:
+                self.presentPopUp(errorString: Const.String.networkFail)
                 print("networkFail")
             }
         }
@@ -212,11 +236,19 @@ extension SignUpThirdViewController {
                 
             case .requestErr(let message):
                 print("requestErr", message)
+                if let message = message as? String {
+                    self.nickNameErrorLabel.isHidden = false
+                    self.nickNameErrorLabel.text = message
+                    self.nickNameBottomView.backgroundColor = .Red
+                }
             case .pathErr:
+                self.presentPopUp(errorString: Const.String.pathErr)
                 print("pathErr")
             case .serverErr:
+                self.presentPopUp(errorString: Const.String.serverErr)
                 print("serverErr")
             case .networkFail:
+                self.presentPopUp(errorString: Const.String.networkFail)
                 print("networkFail")
             }
         }
@@ -251,10 +283,13 @@ extension SignUpThirdViewController {
                     self.nickNameBottomView.backgroundColor = .Red
                 }
             case .pathErr:
+                self.presentPopUp(errorString: Const.String.pathErr)
                 print("pathErr")
             case .serverErr:
+                self.presentPopUp(errorString: Const.String.serverErr)
                 print("serverErr")
             case .networkFail:
+                self.presentPopUp(errorString: Const.String.networkFail)
                 print("networkFail")
             }
         }, email: email, password: password, nickname: nickname)
@@ -278,10 +313,13 @@ extension SignUpThirdViewController {
                 }
                
             case .pathErr:
+                self.presentPopUp(errorString: Const.String.pathErr)
                 print("pathErr")
             case .serverErr:
+                self.presentPopUp(errorString: Const.String.serverErr)
                 print("serverErr")
             case .networkFail:
+                self.presentPopUp(errorString: Const.String.networkFail)
                 print("networkFail")
             }
         }, nickname: nickname)


### PR DESCRIPTION
### Description
- 소셜 로그인 실패 시 에러 띄우기
- pathErr, serverErr, networkFail 발생 시 팝업 띄우기

### Related Issue
Resolve #235